### PR TITLE
ci: add scanner actions and bump all actions

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -7,6 +7,15 @@ runs:
     - name: ci/prepare-docker-environment
       uses: ./.github/actions/docker-prepare
 
+    - name: cd/scan-docker-security
+      uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c # v7.3.2
+      with:
+        image: "mattermost/atlantis"
+        output-format: table
+        only-fixed: true
+        fail-build: false
+        severity-cutoff: critical
+
     - name: cd/push-image-pr
       run: "make push-image-pr"
       shell: bash

--- a/.github/actions/docker-prepare/action.yml
+++ b/.github/actions/docker-prepare/action.yml
@@ -6,6 +6,4 @@ runs:
   using: "composite"
   steps:
     - name: ci/setup-buildx
-      uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # v3.1.0
-      with:
-        version: v0.12.0
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
#### Summary
- add scanner actions and bump all actions: follow up https://github.com/mattermost/mattermost-atlantis-docker/pull/12




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions to latest stable versions across continuous integration pipelines, including checkout and Docker build tooling.
  * Integrated Docker image security scanning with critical severity vulnerability detection and reporting into the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->