### PR TITLE
bump atlantis version to 0.42.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ATLANTIS_VERSION ?= v0.34.0
+ATLANTIS_VERSION ?= v0.42.0
 MATTERMOST_ATLANTIS_IMAGE ?= mattermost/atlantis:test
 PLATFORMS ?= linux/amd64,linux/arm64
 MATTERMOST_ATLANTIS_REPO=mattermost/atlantis


### PR DESCRIPTION
This pull request updates the default Atlantis version used in the `Makefile`. The version is bumped from `v0.34.0` to `v0.42.0`, ensuring the project uses a more recent release of Atlantis.

- Updated the default `ATLANTIS_VERSION` from `v0.34.0` to `v0.42.0` in the `Makefile` to use a newer version of Atlantis.